### PR TITLE
Fix creature level reverting, invisible mobs, unscaled adds, evade healing, and gender-byte writes

### DIFF
--- a/src/DungeonMasterMgr.cpp
+++ b/src/DungeonMasterMgr.cpp
@@ -36,6 +36,7 @@
 #include <set>
 #include <cstdio>
 #include <cmath>
+#include <atomic>
 
 namespace DungeonMaster
 {
@@ -132,10 +133,26 @@ public:
         DoMeleeAttackIfReady();
     }
 
-    void EnterEvadeMode(EvadeReason /*why*/) override
+    // Dungeon Master spawns creatures at generated points, frequently off the
+    // navmesh or far from a home position the core considers reachable. The core
+    // then fires EVADE_REASON_BOUNDARY / EVADE_REASON_NO_PATH mid-fight;
+    // _EnterEvadeMode() drops combat and LoadCreaturesAddon(true) restores the
+    // creature, so it walks home and returns at full health. In play this reads
+    // as a mob that heals faster than the group can damage it.
+    //
+    // Honour genuine resets (empty threat list, sequence break) and refuse the
+    // positional ones while the creature is alive and still engaged. Also
+    // forwards `why`, which the previous override dropped.
+    void EnterEvadeMode(EvadeReason why) override
     {
+        if ((why == EVADE_REASON_BOUNDARY || why == EVADE_REASON_NO_PATH)
+            && me && me->IsAlive() && me->IsInCombat())
+        {
+            return;
+        }
+
         _patrolStarted = false;
-        CreatureAI::EnterEvadeMode();
+        CreatureAI::EnterEvadeMode(why);
     }
 
     void JustDied(Unit* killer) override
@@ -250,6 +267,18 @@ void DungeonMasterMgr::LoadCreaturePools()
         "AND ct.name NOT LIKE '%Server%' "
         "AND ct.name NOT LIKE '%Quest%' "                              // quest scripted mobs
         "AND ct.name NOT LIKE '%zzOLD%' "
+        // Exclude creatures whose display model has no geometry. A
+        // creature_model_info row with BoundingRadius or CombatReach of 0 renders
+        // as nothing client-side: the mob is targetable and fights back, but is
+        // invisible. Roughly 2,100 otherwise-eligible entries in a stock 3.3.5a
+        // world DB are affected, so an entry blacklist does not scale. An entry is
+        // dropped if ANY of its models is degenerate, since the client picks among
+        // them at spawn time.
+        "AND ct.entry NOT IN ("
+        "SELECT ctm2.CreatureID FROM creature_template_model ctm2 "
+        "LEFT JOIN creature_model_info cmi2 ON cmi2.DisplayID = ctm2.CreatureDisplayID "
+        "WHERE ctm2.CreatureDisplayID = 0 OR cmi2.DisplayID IS NULL "
+        "OR cmi2.BoundingRadius <= 0 OR cmi2.CombatReach <= 0) "
         "ORDER BY ct.type, ct.minlevel");
 
     if (!result)
@@ -1134,7 +1163,15 @@ void DungeonMasterMgr::PopulateDungeon(Session* session, InstanceMap* map)
     
         if (isBoss)
         {
-            c->SetByteValue(UNIT_FIELD_BYTES_0, 2, 1);  // Elite rank → gold dragon frame
+            // The gold dragon frame comes from creature_template.rank, which the
+            // client caches per entry — it is not settable at runtime. The boss
+            // pool is already filtered to `rank IN (1,2)`, so every boss draws the
+            // elite frame on its own and nothing is needed here.
+            //
+            // The previous SetByteValue(UNIT_FIELD_BYTES_0, 2, 1) did not set rank:
+            // byte 2 of that field is gender (Unit.h; byte 0=race, 1=class,
+            // 2=gender, 3=power type — there is no classification byte). Its only
+            // effect was to render every boss as gender 1.
             c->SetObjectScale(1.3f);                      // 30% larger than normal
         }
 
@@ -1223,6 +1260,10 @@ void DungeonMasterMgr::PopulateDungeon(Session* session, InstanceMap* map)
 
         // Track this GUID for future cleanup
         guidList.push_back(c->GetGUID());
+
+        // Remember the assigned level so it can be re-asserted if anything
+        // reverts it.
+        RegisterOwnedCreature(c->GetGUID(), targetLevel, hp, instanceId);
     };
 
     // Spawn trash mobs
@@ -1324,8 +1365,9 @@ void DungeonMasterMgr::PopulateDungeon(Session* session, InstanceMap* map)
                     r->SetImmuneToNPC(false);
                     r->setActive(true);
 
-                    // Silver dragon portrait (rank 4 = rare)
-                    r->SetByteValue(UNIT_FIELD_BYTES_0, 2, 4);
+                    // As above: byte 2 is gender, not rank, and 4 is not a valid
+                    // gender value. Rares come from the same `rank IN (1,2)` pool,
+                    // so they already carry an elite frame; size is the extra tell.
                     r->SetObjectScale(1.15f);
 
                     float rareHpMult  = sDMConfig->GetRareHealthMult();
@@ -2630,7 +2672,141 @@ void DungeonMasterMgr::CleanupRoguelikeSession(uint32 sessionId, bool success)
         sessionId, success);
 }
 
-void DungeonMasterMgr::CleanupSession(Session& s) { s.InstanceId = 0; }
+void DungeonMasterMgr::CleanupSession(Session& s)
+{
+    // Release level ownership before the instance id is cleared, otherwise the
+    // map grows for the lifetime of the process.
+    if (s.InstanceId)
+        ForgetOwnedCreaturesForInstance(s.InstanceId);
+
+    s.InstanceId = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Creature level ownership
+//
+// Cheap global gate so the AllCreatureScript hooks cost nothing on a server with
+// no active Dungeon Master session.
+// ---------------------------------------------------------------------------
+static std::atomic<uint32> g_dmOwnedCount{0};
+
+bool DungeonMasterMgr::HasOwnedCreatures()
+{
+    return g_dmOwnedCount.load(std::memory_order_relaxed) != 0;
+}
+
+void DungeonMasterMgr::RegisterOwnedCreature(ObjectGuid guid, uint8 level, uint32 maxHealth, uint32 instanceId)
+{
+    if (!guid || !level)
+        return;
+
+    std::lock_guard<std::mutex> lock(_ownedMutex);
+
+    OwnedCreature& oc = _ownedCreatures[guid];
+    if (oc.Level == 0)
+        g_dmOwnedCount.fetch_add(1, std::memory_order_relaxed);
+
+    oc.Level      = level;
+    oc.MaxHealth  = maxHealth;
+    oc.InstanceId = instanceId;
+}
+
+bool DungeonMasterMgr::GetOwnedCreature(ObjectGuid guid, uint8& level, uint32& maxHealth) const
+{
+    std::lock_guard<std::mutex> lock(_ownedMutex);
+
+    auto it = _ownedCreatures.find(guid);
+    if (it == _ownedCreatures.end())
+        return false;
+
+    level     = it->second.Level;
+    maxHealth = it->second.MaxHealth;
+    return true;
+}
+
+void DungeonMasterMgr::ForgetOwnedCreature(ObjectGuid guid)
+{
+    std::lock_guard<std::mutex> lock(_ownedMutex);
+
+    if (_ownedCreatures.erase(guid))
+        g_dmOwnedCount.fetch_sub(1, std::memory_order_relaxed);
+}
+
+void DungeonMasterMgr::ForgetOwnedCreaturesForInstance(uint32 instanceId)
+{
+    if (!instanceId)
+        return;
+
+    std::lock_guard<std::mutex> lock(_ownedMutex);
+
+    for (auto it = _ownedCreatures.begin(); it != _ownedCreatures.end(); )
+    {
+        if (it->second.InstanceId == instanceId)
+        {
+            it = _ownedCreatures.erase(it);
+            g_dmOwnedCount.fetch_sub(1, std::memory_order_relaxed);
+        }
+        else
+            ++it;
+    }
+}
+
+// Scale an add summoned by a Dungeon Master creature. SelectCreatureForTheme()
+// matches on creature type only and no summon hook was installed, so an add
+// would otherwise enter the instance at its own template level — e.g. a level-69
+// Fel Imp inside a level-25 run, which the client marks with a skull.
+void DungeonMasterMgr::ScaleSummonedCreature(Creature* creature, Session* session)
+{
+    if (!creature || !session)
+        return;
+
+    uint8 targetLevel = session->EffectiveLevel;
+    if (!targetLevel)
+        return;
+
+    creature->SetLevel(targetLevel);
+
+    uint8 unitClass = creature->GetCreatureTemplate()->unit_class;
+    const ClassLevelStatEntry* baseStats = GetBaseStatsForLevel(unitClass, targetLevel);
+
+    float hpMult  = CalculateHealthMultiplier(session);
+    float dmgMult = CalculateDamageMultiplier(session);
+
+    float finalHP = baseStats
+        ? static_cast<float>(baseStats->BaseHP) * hpMult
+        : creature->GetMaxHealth() * hpMult;
+
+    uint32 hp = std::max(1u, static_cast<uint32>(finalHP));
+    creature->SetMaxHealth(hp);
+    creature->SetHealth(hp);
+
+    if (baseStats)
+    {
+        float dmgBase = baseStats->BaseDamage;
+        float apBonus = static_cast<float>(baseStats->AttackPower) / 14.0f;
+        float atkTime = static_cast<float>(creature->GetCreatureTemplate()->BaseAttackTime) / 1000.0f;
+        if (atkTime <= 0.0f)
+            atkTime = 2.0f;
+
+        float minDmg = (dmgBase + apBonus) * atkTime * dmgMult;
+        float maxDmg = ((dmgBase * 1.15f) + apBonus) * atkTime * dmgMult;
+
+        minDmg = std::max(1.0f, minDmg);
+        maxDmg = std::max(minDmg, maxDmg);
+
+        creature->SetBaseWeaponDamage(BASE_ATTACK, MINDAMAGE, minDmg);
+        creature->SetBaseWeaponDamage(BASE_ATTACK, MAXDAMAGE, maxDmg);
+        creature->UpdateDamagePhysical(BASE_ATTACK);
+    }
+
+    if (baseStats && baseStats->BaseArmor > 0)
+        creature->SetArmor(baseStats->BaseArmor);
+
+    for (uint8 school = SPELL_SCHOOL_HOLY; school < MAX_SPELL_SCHOOL; ++school)
+        creature->SetResistance(SpellSchools(school), 0);
+
+    RegisterOwnedCreature(creature->GetGUID(), targetLevel, hp, session->InstanceId);
+}
 
 // Cooldowns
 bool DungeonMasterMgr::IsOnCooldown(ObjectGuid g) const

--- a/src/DungeonMasterMgr.h
+++ b/src/DungeonMasterMgr.h
@@ -92,6 +92,24 @@ public:
     void   DistributeRoguelikeRewards(uint32 tier, uint8 effectiveLevel,
                                        const std::vector<ObjectGuid>& playerGuids);
 
+    // -----------------------------------------------------------------------
+    // Creature level ownership.
+    //
+    // Anything that re-runs Creature::SelectLevel() (respawn, UpdateEntry) or
+    // calls SetLevel() from another module reverts a Dungeon Master creature to
+    // its creature_template level, undoing the level band for the run. We record
+    // what was assigned so it can be re-asserted. Deliberately independent of
+    // which module caused the drift.
+    // -----------------------------------------------------------------------
+    void RegisterOwnedCreature(ObjectGuid guid, uint8 level, uint32 maxHealth, uint32 instanceId);
+    bool GetOwnedCreature(ObjectGuid guid, uint8& level, uint32& maxHealth) const;
+    void ForgetOwnedCreature(ObjectGuid guid);
+    void ForgetOwnedCreaturesForInstance(uint32 instanceId);
+    static bool HasOwnedCreatures();
+
+    // Level + stat scaling for a creature summoned by a Dungeon Master mob.
+    void ScaleSummonedCreature(Creature* creature, Session* session);
+
 private:
     std::vector<SpawnPoint> GetSpawnPointsForMap(uint32 mapId);
     uint32 SelectCreatureForTheme(const Theme* theme, bool isBoss, const Session* session = nullptr);
@@ -134,6 +152,15 @@ private:
 
     std::map<std::pair<uint8,uint8>, ClassLevelStatEntry> _classLevelStats;
     std::unordered_map<uint32, std::vector<ObjectGuid>> _instanceCreatureGuids;
+
+    struct OwnedCreature
+    {
+        uint8  Level      = 0;
+        uint32 MaxHealth  = 0;
+        uint32 InstanceId = 0;
+    };
+    std::unordered_map<ObjectGuid, OwnedCreature> _ownedCreatures;
+    mutable std::mutex _ownedMutex;
 
     std::vector<RewardItem> _rewardItems;
     std::vector<LootPoolItem> _lootPool;

--- a/src/DungeonMaster_loader.cpp
+++ b/src/DungeonMaster_loader.cpp
@@ -10,6 +10,7 @@ void AddSC_dm_world_script();
 void AddSC_dm_allmap_script();
 void AddSC_dm_command_script();
 void AddSC_dm_unit_script();
+void AddSC_dm_allcreature_script();
 
 void Addmod_dungeon_masterScripts()
 {
@@ -21,4 +22,5 @@ void Addmod_dungeon_masterScripts()
     AddSC_dm_allmap_script();
     AddSC_dm_command_script();
     AddSC_dm_unit_script();
+    AddSC_dm_allcreature_script();
 }

--- a/src/scripts/dm_allcreature_script.cpp
+++ b/src/scripts/dm_allcreature_script.cpp
@@ -1,0 +1,134 @@
+/*
+ * mod-dungeon-master - dm_allcreature_script.cpp
+ *
+ * Keeps Dungeon Master creature levels from being reverted, and clamps adds
+ * summoned by Dungeon Master creatures.
+ *
+ * Two independent mechanisms revert an assigned level:
+ *
+ *   1. Creature::SelectLevel() re-rolls urand(minlevel, maxlevel) from
+ *      creature_template. It runs on the respawn path and from
+ *      UpdateEntry(updateAI = true). OnBeforeCreatureSelectLevel lets the module
+ *      supply the owned level instead.
+ *
+ *   2. Another module calling SetLevel() from its own update hook. mod-autobalance
+ *      is the common case: it hooks OnPlayerLevelChanged, marks every creature on
+ *      the map stale, and ResetCreatureIfNeeded() then calls
+ *      SetLevel(UnmodifiedLevel) — the template value. This is why Dungeon Master
+ *      mobs sprout a skull the moment a party member levels up.
+ *
+ * Case 2 is a plain SetLevel() from outside this module, so no core hook can
+ * intercept it. The level is therefore re-asserted on this module's own update
+ * tick, which makes the fix self-healing and independent of script registration
+ * order — it behaves the same whether or not AutoBalance is present. Correcting
+ * on the following tick is imperceptible in play.
+ */
+
+#include "ScriptMgr.h"
+#include "Creature.h"
+#include "Map.h"
+#include "Player.h"
+#include "TemporarySummon.h"
+#include "DungeonMasterMgr.h"
+#include "DMConfig.h"
+
+using namespace DungeonMaster;
+
+class dm_allcreature_script : public AllCreatureScript
+{
+public:
+    dm_allcreature_script() : AllCreatureScript("dm_allcreature_script") {}
+
+    // Runs inside Creature::SelectLevel(), before the rolled level is applied.
+    void OnBeforeCreatureSelectLevel(CreatureTemplate const* /*cinfo*/, Creature* creature, uint8& level) override
+    {
+        if (!creature || !sDMConfig->IsEnabled() || !DungeonMasterMgr::HasOwnedCreatures())
+            return;
+
+        uint8  owned   = 0;
+        uint32 ownedHp = 0;
+        if (sDungeonMasterMgr->GetOwnedCreature(creature->GetGUID(), owned, ownedHp) && owned)
+            level = owned;
+    }
+
+    // Clamp adds summoned by Dungeon Master creatures. Player pets, totems and
+    // guardians are left alone — they belong to the player, not the dungeon.
+    void OnCreatureAddWorld(Creature* creature) override
+    {
+        if (!creature || !sDMConfig->IsEnabled())
+            return;
+
+        Map* map = creature->GetMap();
+        if (!map || !map->IsDungeon())
+            return;
+
+        uint32 instanceId = map->GetInstanceId();
+        if (!instanceId)
+            return;
+
+        if (creature->IsPet() || creature->IsTotem() || creature->IsGuardian())
+            return;
+
+        if (creature->GetCharmerOrOwnerPlayerOrPlayerItself())
+            return;
+
+        // Already owned (the module's own spawn path registers during scaling).
+        uint8  owned   = 0;
+        uint32 ownedHp = 0;
+        if (sDungeonMasterMgr->GetOwnedCreature(creature->GetGUID(), owned, ownedHp))
+            return;
+
+        Session* session = sDungeonMasterMgr->GetSessionByInstance(instanceId);
+        if (!session || !session->IsActive())
+            return;
+
+        if (creature->GetLevel() == session->EffectiveLevel)
+            return;
+
+        sDungeonMasterMgr->ScaleSummonedCreature(creature, session);
+    }
+
+    // Re-assert against silent external SetLevel() calls.
+    void OnAllCreatureUpdate(Creature* creature, uint32 /*diff*/) override
+    {
+        if (!creature || !sDMConfig->IsEnabled() || !DungeonMasterMgr::HasOwnedCreatures())
+            return;
+
+        // Cheap gate: creatures are only ever owned inside instanced dungeons.
+        Map* map = creature->GetMap();
+        if (!map || !map->IsDungeon() || !map->GetInstanceId())
+            return;
+
+        uint8  owned   = 0;
+        uint32 ownedHp = 0;
+        if (!sDungeonMasterMgr->GetOwnedCreature(creature->GetGUID(), owned, ownedHp) || !owned)
+            return;
+
+        if (creature->GetLevel() == owned)
+            return;
+
+        creature->SetLevel(owned);
+
+        // SetLevel() alone leaves the creature with whatever max health the
+        // reverting module computed for the template level, so restore that too.
+        if (ownedHp && creature->GetMaxHealth() != ownedHp)
+        {
+            uint32 cur = creature->GetHealth();
+            creature->SetMaxHealth(ownedHp);
+            creature->SetHealth(std::min(cur ? cur : ownedHp, ownedHp));
+        }
+    }
+
+    void OnCreatureRemoveWorld(Creature* creature) override
+    {
+        if (!creature || !DungeonMasterMgr::HasOwnedCreatures())
+            return;
+
+        sDungeonMasterMgr->ForgetOwnedCreature(creature->GetGUID());
+    }
+};
+
+void AddSC_dm_allcreature_script()
+{
+    new dm_allcreature_script();
+}


### PR DESCRIPTION
Five defects, all observed on a live realm running this module. Happy to split
this into separate PRs if you'd rather review them independently — they're
described separately below and touch mostly distinct code.

### 1. Spawned creature levels revert (#13)

`Creature::SelectLevel()` re-rolls `urand(minlevel, maxlevel)` straight from
`creature_template` on the respawn path and from `UpdateEntry(updateAI = true)`,
and other modules call `SetLevel()` from their own update hooks. mod-autobalance
is the common case: it hooks `OnPlayerLevelChanged`, marks every creature on the
map stale, and `ResetCreatureIfNeeded()` then calls `SetLevel(UnmodifiedLevel)` —
the template value. Either way the level band chosen for the run is lost, which
is why mobs sprout a skull the moment a party member levels up.

The manager now records the level and max health it assigns and re-asserts them:

* case 1 is intercepted via `OnBeforeCreatureSelectLevel`;
* case 2 is a plain `SetLevel()` from outside this module and cannot be hooked,
  so it is corrected on this module's own update tick.

Doing it on our own tick keeps the fix self-healing and independent of script
registration order, so it behaves identically with or without AutoBalance
present. An atomic counter gates the hooks so they cost nothing when no session
is running, and ownership is released on creature removal and on session cleanup.

### 2. Invisible mobs

The trash pool filtered suspicious *names* but not degenerate *models*. A
`creature_model_info` row with `BoundingRadius` or `CombatReach` of 0 renders as
nothing client-side: the mob is targetable and fights back, but cannot be seen.

Around 2,100 otherwise-eligible entries in a stock 3.3.5a world DB are affected,
so a name filter or an entry blacklist doesn't scale. The pool query now drops any
entry with a degenerate model, checking every model an entry has, since the client
picks among them at spawn time. On my world DB the trash pool goes from 13,600 to
11,480 entries with all nine creature types still well populated.

### 3. Summoned adds keep their own level

`SelectCreatureForTheme()` matches on creature type only and there was no summon
hook, so an add summoned by a dungeon creature entered at its own template level —
e.g. a level-69 Fel Imp inside a level-25 run. Adds are now scaled to the session
level via `OnCreatureAddWorld`. Player pets, totems and guardians are explicitly
excluded.

### 4. Creatures heal to full mid-fight

Creatures are spawned at generated points, frequently off the navmesh or far from
a home position the core considers reachable, so the core fires
`EVADE_REASON_BOUNDARY` / `EVADE_REASON_NO_PATH` during combat. `_EnterEvadeMode()`
drops combat and `LoadCreaturesAddon(true)` restores the creature, which then walks
home at full health — in play, a mob that heals faster than the group can damage it.

Genuine resets (empty threat list, sequence break) are honoured; the positional
ones are refused while the creature is alive and still engaged. The override also
forwards `why`, which the previous one dropped.

### 5. Bogus `UNIT_FIELD_BYTES_0` writes

Two sites wrote byte 2 of `UNIT_FIELD_BYTES_0` intending to set elite/rare rank:

```cpp
c->SetByteValue(UNIT_FIELD_BYTES_0, 2, 1);  // Elite rank -> gold dragon frame
r->SetByteValue(UNIT_FIELD_BYTES_0, 2, 4);  // Silver dragon portrait
```

That byte is **gender** (byte 0 = race, 1 = class, 2 = gender, 3 = power type — the
field has no classification byte). Rank lives in `creature_template` and is cached
by the client per entry, so it can't be set at runtime at all. The writes only
changed gender, and the "rare" site wrote 4, which isn't a valid gender value.

Both are removed, and nothing is lost: the boss and rare pools are already filtered
to `rank IN (1,2)` (305 rank-1 and 2 rank-2 entries on my world DB, i.e. all of
them), so those creatures carry an elite frame from their template and the client
draws the dragon portrait on its own. The `SetObjectScale()` calls are deliberate
design and are kept.

### Testing

Compiled with `-DMODULES=static` against AzerothCore rev `190184a04539` (Playerbot
branch) and deployed to a live realm. Clean boot, no errors, `restarts=0`, and the
pool loads 8,585 trash / 2,895 boss entries across all nine creature types.

One note on scope: I left the gold-reward calculation alone. It uses the session
level rather than the killed creature's level, which interacts oddly with fix 3,
but that's a design call rather than a defect so it seemed better left to you.
