### PR TITLE
Fix use-after-free segfault in stray creature sweep

### DIFF
--- a/src/DungeonMasterMgr.cpp
+++ b/src/DungeonMasterMgr.cpp
@@ -3529,6 +3529,12 @@ void DungeonMasterMgr::Update(uint32 diff)
                     if (m && m->IsDungeon())
                     {
                         uint32 npcEntry = sDMConfig->GetNpcEntry();
+
+                        // Collect matches first: DespawnOrUnsummon() mutates the map's
+                        // creature-by-spawnId container, so we must not call it while
+                        // still holding a live iterator over that same container
+                        // (was causing use-after-free segfaults on the next iteration).
+                        std::vector<Creature*> strays;
                         auto const& dbStore = static_cast<InstanceMap*>(m)->GetCreatureBySpawnIdStore();
                         for (auto const& pair : dbStore)
                         {
@@ -3538,9 +3544,14 @@ void DungeonMasterMgr::Update(uint32 diff)
                                 && !stray->IsPet() && !stray->IsGuardian() && !stray->IsTotem()
                                 && ourGuids.count(stray->GetGUID()) == 0)
                             {
-                                stray->SetRespawnTime(7 * DAY);
-                                stray->DespawnOrUnsummon();
+                                strays.push_back(stray);
                             }
+                        }
+
+                        for (Creature* stray : strays)
+                        {
+                            stray->SetRespawnTime(7 * DAY);
+                            stray->DespawnOrUnsummon();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

The stray-creature sweep in `DungeonMasterMgr::Update()` iterates `InstanceMap::GetCreatureBySpawnIdStore()` by reference and calls `DespawnOrUnsummon()` on matches inside that same loop. With the default 0ms delay, `DespawnOrUnsummon()` resolves synchronously (`Creature::ForcedDespawn` → `RemoveCorpse` → map removal happens in-line, not deferred to a later tick), which erases the very element the range-for loop's iterator currently points to. Incrementing that now-invalidated iterator is undefined behavior.

In practice this segfaulted reliably: entering the roguelike/dungeon-master dungeon with any ordinary DB-spawned trash creature nearby (i.e. almost any populated dungeon map) crashed worldserver within seconds. Confirmed via gdb on three separate core dumps, all with the identical stack:

```
#0 DungeonMasterMgr::Update (...) at .../Object.h:109  [IsInWorld() on a dangling Creature*]
#1 dm_world_script::OnUpdate
#2 ScriptMgr::OnWorldUpdate
```

## Fix

Separates the read pass from the write pass: matching creatures are collected into a local `std::vector<Creature*>` while iterating the store, then despawned in a second loop after iteration over the store has fully completed. No behavior change other than removing the use-after-free.

## Test plan

- [x] Reproduced the crash locally (3x, gdb backtraces confirmed identical root cause)
- [x] Applied the fix, rebuilt worldserver, ran the roguelike dungeon repeatedly with no recurrence
- [ ] Would appreciate a maintainer sanity-check on any edge case around creatures despawned this tick still being visible to later code in the same `Update()` call (none currently rely on it, from what I can see)